### PR TITLE
Pack Ball under Lobot python module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,7 @@ add_library(bot_utils STATIC
 target_include_directories(bot_utils PUBLIC inc/)
 target_compile_features(bot_utils PUBLIC cxx_std_11)
 
-# pybind11_add_module(${PROJECT_NAME} src/bot.cpp)
-pybind11_add_module(${PROJECT_NAME} src/Ball.cpp)
+pybind11_add_module(${PROJECT_NAME} src/lobot.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE bot_utils)
 target_include_directories(${PROJECT_NAME} PRIVATE inc/)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,8 @@ add_library(bot_utils STATIC
 target_include_directories(bot_utils PUBLIC inc/)
 target_compile_features(bot_utils PUBLIC cxx_std_11)
 
-pybind11_add_module(${PROJECT_NAME} src/bot.cpp)
+# pybind11_add_module(${PROJECT_NAME} src/bot.cpp)
+pybind11_add_module(${PROJECT_NAME} src/Ball.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE bot_utils)
 target_include_directories(${PROJECT_NAME} PRIVATE inc/)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)

--- a/src/Ball.cpp
+++ b/src/Ball.cpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Ball.h"
+#include <pybind11/pybind11.h>
+
+PYBIND11_MODULE(Lobot, m) {
+	pybind11::class_<Ball>(m, "Ball")
+		.def(pybind11::init<>())
+		.def_readwrite("position", &Ball::x)
+		.def_readwrite("velocity", &Ball::v)
+		.def_readwrite("angular_velocity", &Ball::w)
+		.def("step", &Ball::step);
+}

--- a/src/bot.cpp
+++ b/src/bot.cpp
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <thread>
-#include <pybind11/pybind11.h>
-
 #include "RL_structs.h"
 
 class Bot {
@@ -35,8 +33,3 @@ private:
 
 };
 
-PYBIND11_MODULE(Lobot, m) {
-  pybind11::class_<Bot>(m, "Bot")
-    .def(pybind11::init<int>())
-    .def("get_response", &Bot::get_response);
-}

--- a/src/lobot.cpp
+++ b/src/lobot.cpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "bot.cpp"
 #include "Ball.h"
+
 #include <pybind11/pybind11.h>
 
 PYBIND11_MODULE(Lobot, m) {
@@ -10,4 +12,8 @@ PYBIND11_MODULE(Lobot, m) {
 		.def_readwrite("velocity", &Ball::v)
 		.def_readwrite("angular_velocity", &Ball::w)
 		.def("step", &Ball::step);
+	
+	pybind11::class_<Bot>(m, "Bot")
+		.def(pybind11::init<int>())
+		.def("get_response", &Bot::get_response);
 }


### PR DESCRIPTION
This does seem to work properly - e.g. can call 

```
import Lobot
ball = Lobot.Ball()
```
However since the mesh file is missing, it fails right away on `file not found` error.